### PR TITLE
Add Subroutine for Even or Odd Number Check

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/Perl-Scripting.iml
+++ b/.idea/Perl-Scripting.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="openjdk-22" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Perl-Scripting.iml" filepath="$PROJECT_DIR$/.idea/Perl-Scripting.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Perl-Scripting/sub_routine_prob.pl
+++ b/Perl-Scripting/sub_routine_prob.pl
@@ -1,0 +1,17 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+# Subroutine to check even or odd
+sub check_even_odd {
+    my ($num) = @_;  # Get the number from arguments
+    return $num % 2 == 0 ? "$num is Even\n" : "$num is Odd\n";
+}
+
+# Taking user input
+print "Enter a number: ";
+my $num = <STDIN>;
+chomp($num);
+
+# Calling the subroutine and printing result
+print check_even_odd($num);


### PR DESCRIPTION
Description:

This pull request introduces a new Perl script that checks whether a given number is even or odd using a subroutine. The script follows best practices, including strict and warnings for better debugging.

Changes Made:

1. Added a subroutine check_even_odd($num) to determine if a number is even or odd.
2. Used STDIN for user input and chomp to handle newline characters.
3. Implemented a ternary conditional operator to return the result concisely.

How It Works:

1. The script prompts the user to enter a number.
2. The input is passed to the check_even_odd subroutine.
3. The subroutine evaluates the number and returns either "Even" or "Odd".
4. The result is printed to the console.

Testing:

Tested with multiple inputs to verify correctness.
Handles both even and odd numbers correctly.

Example output:
`Enter a number: 8 
8 is Even `